### PR TITLE
Merge variation manager role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,10 @@ module "default-project-roles" {
     key  = "default"
     name = "Default project"
   }
+  // allows flag managers to update flag variations, only enable if at least env enforces approvals
+  with_seperate_variation_manager = false 
+  // enable/disable createApprovalRequest in view role, defaults to true
+  // viewers_can_request_changes = false
   environments = {
     "test" = {
       key = "test"
@@ -53,6 +57,7 @@ module "sandbox-prefix-project-roles" {
   // we need to set it since `sandbox-*` is not a valid role key
   // example roles: flag-manager-sandbox, archiver-sandbox, etc
   role_key = "sandbox"
+  with_seperate_variation_manager = false 
   environments = {
     "test" = {
       key = "test"
@@ -72,7 +77,7 @@ module "preproduction-production-roles" {
     key  = "default"
     name = "Default project"
   }
-
+  with_seperate_variation_manager = false 
   environments = {
     // the map key is used to generate role keys
     // for example: flag-maintainer-default-preproduction

--- a/roles/flag-lifecycle/all-environments.tf
+++ b/roles/flag-lifecycle/all-environments.tf
@@ -1,15 +1,18 @@
 output "project-roles"{
     description = "Project-level flag lifecycle management roles"
-    value = {
+    value = merge(
+    {
         "view-project" = launchdarkly_custom_role.view-project,
         "sdk-key" = launchdarkly_custom_role.sdk-key,
         "flag-manager" = launchdarkly_custom_role.flag-manager,
         "release-manager" = launchdarkly_custom_role.release-manager,
         "flag-archiver" = launchdarkly_custom_role.flag-archiver,
-        "variation-manager" = launchdarkly_custom_role.variation-manager,
-        "sdk-manager" = launchdarkly_custom_role.sdk-manager
-
-    }
+        "sdk-manager" = launchdarkly_custom_role.sdk-manager,
+        "approver" = launchdarkly_custom_role.approver-all
+        "apply-changes" = launchdarkly_custom_role.apply-changes-all
+    }, var.with_seperate_variation_manager ? {
+        "variation-manager" = launchdarkly_custom_role.variation-manager[0]
+    } : {})
 }
 
 /// Read only access to a subset of projects
@@ -23,14 +26,7 @@ resource launchdarkly_custom_role "view-project" {
   policy_statements {
     effect    = "allow"
     resources = ["proj/${local.project.specifier}"]
-    actions   = ["viewProject"]
-  }
-  
-  policy_statements {
-    effect    = "allow"
-    resources = ["proj/${local.project.specifier}:env/*:flag/*"]
-    actions   = ["createApprovalRequest"]
-
+    actions   = concat(["viewProject"], var.viewers_can_request_changes ? ["createApprovalRequest"] : [])
   }
 }
 
@@ -43,7 +39,27 @@ resource launchdarkly_custom_role "flag-manager" {
   policy_statements {
     effect    = "allow"
     resources = ["proj/${local.project.specifier}:env/*:flag/*"]
-    actions   = ["cloneFlag", "createFlag", "createFlagLink", "deleteFlagLink", "updateDescription", "updateFlagCustomProperties", "updateFlagDefaultVariations", "updateFlagLink", "updateMaintainer", "updateName", "updateTags", "updateTemporary"]
+    actions   = concat([
+      /* 
+       *  Always include createApprovalRequest to prevent
+       *  unintended consequences if you remove it from view project
+       */
+        "createApprovalRequest",
+        "cloneFlag",
+        "createFlag",
+        "createFlagLink",
+        "deleteFlagLink",
+        "updateDescription",
+        "updateFlagCustomProperties",
+        "updateFlagDefaultVariations",
+        "updateFlagLink",
+        "updateMaintainer",
+        "updateName",
+        "updateTags",
+        "updateTemporary"
+      ], var.with_seperate_variation_manager ? [
+        "updateFlagVariations"
+      ] : [])
 
   }
 }
@@ -62,6 +78,7 @@ resource launchdarkly_custom_role "flag-archiver" {
 }
 
 resource launchdarkly_custom_role "variation-manager" {
+  count = var.with_seperate_variation_manager ? 1 : 0
   key              = "varmgr-${local.project.key}"
   name             = "Variation Manager - ${local.project.name}"
   description      = "Impacts evaluation of existing flags in all environments"
@@ -73,6 +90,8 @@ resource launchdarkly_custom_role "variation-manager" {
     actions   = ["updateFlagVariations"]
   }
 }
+
+
 
 resource launchdarkly_custom_role "sdk-manager" {
   key              = "sdk-mgr-${local.project.key}"
@@ -89,3 +108,28 @@ resource launchdarkly_custom_role "sdk-manager" {
 }
 
 
+resource launchdarkly_custom_role "approver-all" {
+  key              = "approver-${local.project.key}"
+  name             = "Approver - ${local.project.name}"
+  description      = "Can review, update, and delete approval requests in all environments. Can not apply approval requests."
+  base_permissions = "no_access"
+
+  policy_statements {
+    effect    = "allow"
+    resources = ["proj/${local.project.specifier}:env/*:flag/*"]
+    actions   = ["updateApprovalRequest"]
+  }
+}
+
+resource launchdarkly_custom_role "apply-changes-all" {
+  key              = "applier-all-${local.project.key}"
+  name             = "Applier - ${local.project.name}"
+  description      = "Can apply approved changes in all environments"
+  base_permissions = "no_access"
+
+  policy_statements {
+    effect    = "allow"
+    resources = ["proj/${local.project.specifier}:env/*:flag/*"]
+    actions   = ["applyApprovalRequest"]
+  }
+}

--- a/roles/flag-lifecycle/per-environment.tf
+++ b/roles/flag-lifecycle/per-environment.tf
@@ -43,6 +43,9 @@ resource "launchdarkly_custom_role" "release-manager" {
     effect    = "allow"
     resources = ["proj/${local.project.specifier}:env/${each.value.specifier}:flag/*"]
     actions = [
+      // explictly include `createApprovalRequest` so this role
+      // works well even when viewers_can_request_changes is false
+      "createApprovalRequest",
       "copyFlagConfigFrom",
       "copyFlagConfigTo",
       "createApprovalRequest",
@@ -131,7 +134,7 @@ resource "launchdarkly_custom_role" "apply-changes" {
   for_each         = local.environments
   key              = "applier-${local.project.key}-${each.key}"
   name             = "Applier - ${local.project.name} - ${each.value.name}"
-  description      = "Can apply approved changes in production"
+  description      = "Can apply approved changes in ${each.value.name}"
   base_permissions = "no_access"
 
   policy_statements {

--- a/roles/flag-lifecycle/variables.tf
+++ b/roles/flag-lifecycle/variables.tf
@@ -34,6 +34,18 @@ variable "environments" {
   }
 }
 
+variable "with_variation_manager" {
+    type = bool
+    description = "Whether to generate a role for variation manager. If false, flag manager will have updateFlagVariations permission"
+    default = false
+}
+
+variable "viewers_can_request_changes" {
+    type = bool
+    description = "When true, `createApprovalRequest` will be included in the view project role"
+    default = true
+}
+
 variable "environment_excludes" {
     type = map(list(string))
     description = "Map of environment keys to a list of environments to generate deny statements for when creating environment-levle roles"


### PR DESCRIPTION
- Adds a setting to merge variation manager into the flag manager role with `with_seperate_varation_manager=false`
- Adds a setting toggle createApprovalRequest in the view role wih `viewers_can_request_changes`
- Always creates project level approvers and appliers
- Always includes createApprovalReques in any role with actions that support approvals (flag manager and release manager)