### PR TITLE
Add Context Manager

### DIFF
--- a/roles/flag-lifecycle/variables.tf
+++ b/roles/flag-lifecycle/variables.tf
@@ -12,6 +12,12 @@ variable "role_key" {
     default = null
 }
 
+variable "with_seperate_context_manager" {
+    type = bool
+    description = "Whether to generate a role for context manager. If false, flag manager will have createContextKind, deleteContextKind, and updateContextKind permissions"
+    default = true
+}
+
 variable "environments" {
     type = map(object({
         name = string


### PR DESCRIPTION
- Adds a Context Manager role with the ability to create and modify context kinds
- Adds setting `with_seperate_context_manager` which defaults to true
- When `with_seperate_context_manager` is true, a per-project context manager role with be created
- When `with_seperate_context_manager` is false, flag manager will have context manager permissions and no additional role will be created